### PR TITLE
Support for c# extensions

### DIFF
--- a/samples/DataLoaderWithEFCore/DataLoaderWithEFCore/DataLoaderWithEFCore.csproj
+++ b/samples/DataLoaderWithEFCore/DataLoaderWithEFCore/DataLoaderWithEFCore.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="7.0.1" />
-    <PackageReference Include="GraphQL.Conventions" Version="2.0.1" />
+    <PackageReference Include="GraphQL.Conventions" Version="2.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.1.2" PrivateAssets="All" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.1.4" />

--- a/src/GraphQL.Conventions/Adapters/Resolvers/FieldResolver.cs
+++ b/src/GraphQL.Conventions/Adapters/Resolvers/FieldResolver.cs
@@ -58,6 +58,11 @@ namespace GraphQL.Conventions.Adapters
                 .Arguments
                 .Select(arg => context.GetArgument(arg));
 
+            if (fieldInfo.IsExtensionMethod)
+            {
+                arguments = new[] { source }.Concat(arguments);
+            }
+
             return methodInfo?.Invoke(source, arguments.ToArray());
         }
 

--- a/src/GraphQL.Conventions/CommonAssemblyInfo.cs
+++ b/src/GraphQL.Conventions/CommonAssemblyInfo.cs
@@ -8,8 +8,8 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyCopyright("Copyright 2016-2017 Tommy Lillehagen. All rights reserved.")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("2.0.1")]
-[assembly: AssemblyInformationalVersion("2.0.1")]
+[assembly: AssemblyFileVersion("2.0.2")]
+[assembly: AssemblyInformationalVersion("2.0.2")]
 [assembly: CLSCompliant(false)]
 
 [assembly: InternalsVisibleTo("Tests")]

--- a/src/GraphQL.Conventions/GraphQL.Conventions.csproj
+++ b/src/GraphQL.Conventions/GraphQL.Conventions.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>GraphQL Conventions for .NET</Description>
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <VersionPrefix>2.0.2</VersionPrefix>
     <Authors>Tommy Lillehagen</Authors>
     <TargetFrameworks>netstandard1.6.1;net45</TargetFrameworks>
     <DebugType>portable</DebugType>

--- a/src/GraphQL.Conventions/Types/Descriptors/GraphFieldInfo.cs
+++ b/src/GraphQL.Conventions/Types/Descriptors/GraphFieldInfo.cs
@@ -13,7 +13,6 @@ namespace GraphQL.Conventions.Types.Descriptors
         public GraphFieldInfo(ITypeResolver typeResolver, MemberInfo field = null)
             : base(typeResolver, field)
         {
-            IsExtensionMethod = (AttributeProvider as MethodInfo)?.IsExtensionMethod() ?? false;
         }
 
         public GraphTypeInfo DeclaringType { get; set; }
@@ -32,7 +31,7 @@ namespace GraphQL.Conventions.Types.Descriptors
 
         public bool IsMethod => AttributeProvider is MethodInfo;
 
-        public bool IsExtensionMethod { get; private set; }
+        public bool IsExtensionMethod => (AttributeProvider as MethodInfo).IsExtensionMethod();
 
         public override string ToString() => $"{nameof(GraphFieldInfo)}:{Name}";
     }

--- a/src/GraphQL.Conventions/Types/Descriptors/GraphFieldInfo.cs
+++ b/src/GraphQL.Conventions/Types/Descriptors/GraphFieldInfo.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using GraphQL.Conventions.Attributes;
 using GraphQL.Conventions.Types.Resolution;
+using GraphQL.Conventions.Types.Resolution.Extensions;
 
 namespace GraphQL.Conventions.Types.Descriptors
 {
@@ -12,6 +13,7 @@ namespace GraphQL.Conventions.Types.Descriptors
         public GraphFieldInfo(ITypeResolver typeResolver, MemberInfo field = null)
             : base(typeResolver, field)
         {
+            IsExtensionMethod = (AttributeProvider as MethodInfo)?.IsExtensionMethod() ?? false;
         }
 
         public GraphTypeInfo DeclaringType { get; set; }
@@ -29,6 +31,8 @@ namespace GraphQL.Conventions.Types.Descriptors
             new List<IExecutionFilterAttribute>();
 
         public bool IsMethod => AttributeProvider is MethodInfo;
+
+        public bool IsExtensionMethod { get; private set; }
 
         public override string ToString() => $"{nameof(GraphFieldInfo)}:{Name}";
     }

--- a/src/GraphQL.Conventions/Types/Resolution/Extensions/ReflectionExtensions.cs
+++ b/src/GraphQL.Conventions/Types/Resolution/Extensions/ReflectionExtensions.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using GraphQL.Conventions.Types.Descriptors;
 
@@ -109,6 +110,11 @@ namespace GraphQL.Conventions.Types.Resolution.Extensions
                 .GetMethod("ConvertToArray", BindingFlags.Static | BindingFlags.Public);
             var genericMethod = convertMethod.MakeGenericMethod(elementType);
             return genericMethod.Invoke(null, new object[] {list});
+        }
+
+        public static bool IsExtensionMethod(this MethodInfo methodInfo)
+        {
+            return methodInfo.IsDefined(typeof(ExtensionAttribute), false);
         }
     }
 }

--- a/src/GraphQL.Conventions/Types/Resolution/Extensions/ReflectionExtensions.cs
+++ b/src/GraphQL.Conventions/Types/Resolution/Extensions/ReflectionExtensions.cs
@@ -114,7 +114,7 @@ namespace GraphQL.Conventions.Types.Resolution.Extensions
 
         public static bool IsExtensionMethod(this MethodInfo methodInfo)
         {
-            return methodInfo.IsDefined(typeof(ExtensionAttribute), false);
+            return methodInfo?.IsDefined(typeof(ExtensionAttribute), false) ?? false;
         }
     }
 }

--- a/src/GraphQL.Conventions/Types/Resolution/ITypeResolver.cs
+++ b/src/GraphQL.Conventions/Types/Resolution/ITypeResolver.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Reflection;
 using GraphQL.Conventions.Types.Descriptors;
 
@@ -20,6 +21,8 @@ namespace GraphQL.Conventions.Types.Resolution
         TypeRegistration LookupType(TypeInfo typeInfo);
 
         void IgnoreTypesFromNamespacesStartingWith(params string[] namespacesToIgnore);
+
+        void AddExtensions(Type typeExtensions);
 
         GraphSchemaInfo ActiveSchema { get; set; }
     }

--- a/src/GraphQL.Conventions/Types/Resolution/ObjectReflector.cs
+++ b/src/GraphQL.Conventions/Types/Resolution/ObjectReflector.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using GraphQL.Conventions.Handlers;
 using GraphQL.Conventions.Types.Descriptors;
 using GraphQL.Conventions.Types.Resolution.Extensions;

--- a/src/GraphQL.Conventions/Types/Resolution/ObjectReflector.cs
+++ b/src/GraphQL.Conventions/Types/Resolution/ObjectReflector.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using GraphQL.Conventions.Handlers;
 using GraphQL.Conventions.Types.Descriptors;
 using GraphQL.Conventions.Types.Resolution.Extensions;
@@ -27,11 +28,26 @@ namespace GraphQL.Conventions.Types.Resolution
 
         private readonly MetaDataAttributeHandler _metaDataHandler = new MetaDataAttributeHandler();
 
+        private readonly Dictionary<Type, List<MethodInfo>> _typeExtensionMethods = new Dictionary<Type, List<MethodInfo>>();
+
         public HashSet<string> IgnoredNamespaces { get; } = new HashSet<string>() { nameof(System) + "." };
 
         public ObjectReflector(ITypeResolver typeResolver)
         {
             _typeResolver = typeResolver;
+        }
+
+        public void AddExtensions(TypeInfo typeExtensions)
+        {
+            var extensionMethods = typeExtensions
+                .GetMethods(BindingFlags.Static | BindingFlags.Public)
+                .Where(m => m.IsExtensionMethod())
+                .GroupBy(m => m.GetParameters()[0].ParameterType);
+
+            foreach (var methodGroup in extensionMethods)
+            {
+                GetExtensionMethods(methodGroup.Key).AddRange(methodGroup);
+            }
         }
 
         public GraphSchemaInfo GetSchema(TypeInfo typeInfo)
@@ -185,6 +201,20 @@ namespace GraphQL.Conventions.Types.Resolution
         private TypeInfo GetTypeInfo(ICustomAttributeProvider attributeProvider) =>
             ((TypeInfo)attributeProvider).GetTypeRepresentation();
 
+        private List<MethodInfo> GetExtensionMethods(TypeInfo typeInfo)
+            => GetExtensionMethods(typeInfo.UnderlyingSystemType);
+
+        private List<MethodInfo> GetExtensionMethods(Type type)
+        {
+            List<MethodInfo> methods;
+            if (!_typeExtensionMethods.TryGetValue(type, out methods))
+            {
+                methods = new List<MethodInfo>();
+                _typeExtensionMethods.Add(type, methods);
+            }
+            return methods;
+        }
+
         private IEnumerable<GraphFieldInfo> GetFields(TypeInfo typeInfo)
         {
             var implementedProperties = typeInfo
@@ -204,6 +234,7 @@ namespace GraphQL.Conventions.Types.Resolution
             return typeInfo
                 .GetMethods(DefaultBindingFlags)
                 .Union(implementedMethods)
+                .Union(GetExtensionMethods(typeInfo))
                 .Where(IsValidMember)
                 .Where(methodInfo => !methodInfo.IsSpecialName)
                 .Cast<MemberInfo>()
@@ -217,6 +248,7 @@ namespace GraphQL.Conventions.Types.Resolution
         {
             foreach (var argument in methodInfo?
                 .GetParameters()
+                .Skip(methodInfo.IsExtensionMethod() ? 1 : 0)
                 .Select(DeriveArgument)
                 ?? new GraphArgumentInfo[0])
             {

--- a/src/GraphQL.Conventions/Types/Resolution/TypeResolver.cs
+++ b/src/GraphQL.Conventions/Types/Resolution/TypeResolver.cs
@@ -97,5 +97,8 @@ namespace GraphQL.Conventions.Types.Resolution
             foreach (var @namespace in namespacesToIgnore.Distinct())
                 _reflector.IgnoredNamespaces.Add(@namespace);
         }
+
+        public void AddExtensions(Type typeExtensions) =>
+            _reflector.AddExtensions(typeExtensions.GetTypeInfo());
     }
 }

--- a/src/GraphQL.Conventions/Web/RequestHandler.cs
+++ b/src/GraphQL.Conventions/Web/RequestHandler.cs
@@ -90,6 +90,12 @@ namespace GraphQL.Conventions.Web
                 return this;
             }
 
+            public RequestHandlerBuilder WithQueryExtensions(Type typeExtensions)
+            {
+                _typeResolver.AddExtensions(typeExtensions);
+                return this;
+            }
+
             public RequestHandlerBuilder WithSubscription<TSubscription>()
             {
                 _schemaTypes.Add(typeof(SchemaDefinitionWithSubscription<TSubscription>));

--- a/test/Tests/Web/RequestHandlerTests.cs
+++ b/test/Tests/Web/RequestHandlerTests.cs
@@ -96,6 +96,64 @@ namespace GraphQL.Conventions.Tests.Web
             response.Body.ShouldContain("VALIDATION_ERROR");
         }
 
+        [Test]
+        public async Task Can_Run_Query_With_Type_Extensions()
+        {
+            var request = Request.New("{ \"query\": \"{ helloExtended(v: 10) }\" }");
+            var response = await RequestHandler
+                .New()
+                .WithQuery<SimpleQuery>()
+                .WithQueryExtensions(typeof(QueryExtensions))
+                .Generate()
+                .ProcessRequest(request, null, null);
+
+            response.ExecutionResult.Data.ShouldHaveFieldWithValue("helloExtended", "Extended-10");
+            response.Body.ShouldEqual("{\"data\":{\"helloExtended\":\"Extended-10\"}}");
+            response.Errors.Count.ShouldEqual(0);
+            response.Warnings.Count.ShouldEqual(0);
+        }
+
+        [Test]
+        public async Task Can_Run_Query_With_Nested_Type_Extensions()
+        {
+            var request = Request.New("{ \"query\": \"{ helloType(v: 1) { myName }}\" }");
+            var response = await RequestHandler
+                .New()
+                .WithQuery<SimpleQuery>()
+                .WithQueryExtensions(typeof(QueryExtensions))
+                .Generate()
+                .ProcessRequest(request, null, null);
+
+            response.Body.ShouldEqual("{\"data\":{\"helloType\":{\"myName\":\"Name-1\"}}}");
+            response.Errors.Count.ShouldEqual(0);
+            response.Warnings.Count.ShouldEqual(0);
+        }
+
+        [Test]
+        public void Can_Construct_And_Describe_Schema_With_Extensions()
+        {
+            var schema = RequestHandler
+                .New()
+                .WithQuery<SimpleQuery>()
+                .WithQueryExtensions(typeof(QueryExtensions))
+                .Generate()
+                .DescribeSchema(false, false, false);
+
+            schema.ShouldEqualWhenReformatted(@"
+                schema {
+                    query: SimpleQuery
+                }
+                type HelloType {
+                    myName: String
+                }
+                type SimpleQuery {
+                    hello: String
+                    helloExtended(v: Int!): String
+                    helloType(v: Int!): HelloType
+                }
+            ");
+        }
+
         class TestQuery
         {
             public string Hello => "World";
@@ -124,6 +182,30 @@ namespace GraphQL.Conventions.Tests.Web
             public TestQuery Earth => new TestQuery();
             public Unwanted.TestQuery2 Mars => new Unwanted.TestQuery2();
         }
+    }
+
+    class SimpleQuery
+    {
+        public string Hello => "World";
+        public HelloType HelloType(int v) => new HelloType(v);
+    }
+
+    class HelloType
+    {
+        [Ignore]
+        public int HiddenVersion { get; set; }
+
+        public HelloType(int v)
+        {
+            HiddenVersion = v;
+        }
+    }
+
+    static class QueryExtensions
+    {
+        public static string HelloExtended(this SimpleQuery query, int v) => $"Extended-{v}";
+
+        public static string MyName(this HelloType helloType) => $"Name-{helloType.HiddenVersion}";
     }
 
     namespace Unwanted


### PR DESCRIPTION
This PR introduces support for C# extensions to add to the definition of a query type. 

This is particularly useful when the schema is defined across several projects / assemblies and you wish to stitch these together into a single graph.

```
// Actors.csproj
class Actor
{
   public Guid Id { get; set; }
   public string Name { get; set; }
}

// Movies.csproj
class Movie
{
    public Guid Id { get; set; }
    public string Title { get; set; }
}

// Schema.csproj
static class MovieExtensions
{
    public async Task<Actor[]> Actors(this Movie movie, [Inject] IActorRepository repository)
       => await repository.GetActorsPerMovie(movie.Id);
}
class Query
{
    public async Task<Movie> Movie([Inject] IMovieRepository repository, Guid id)
       => await repository.GetMovie(.id);
}

var response = await RequestHandler
  .New()
  .WithQuery<Query>()
  .WithQueryExtensions(typeof(MovieExtensions))
  .Generate();
```